### PR TITLE
Opening strategies and general plugin structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,17 @@ wildignore flag directly in your `.vimrc` configuration file.
 :set wildignore+=**/vendor/**
 ```
 
+## Open Strategy
+
+The open strategy comes in help when you want to open the related test
+in a new window, split, tab etc..
+
+```viml
+let g:relatedtest_open_strategy = 'vsp'
+```
+
+You can use any vim command as open strategy, the most common are:
+- vsp (open in a vertical split)
+- sp (open in an horizontal split)
+- tabnew (open in a tab)
+- e (open in the current window)

--- a/autoload/relatedtest.vim
+++ b/autoload/relatedtest.vim
@@ -22,18 +22,18 @@ function! s:GetInputResponse(prompt, inputChoices)
 endfunction
 
 function! relatedtest#handleTT()
-    let a:bufname = bufname('%')
-    if RelatedTestIsTest(a:bufname) > 0
-        let relatedtest_filename = RelatedTestGetFileName(a:bufname)
+    let bufname = bufname('%')
+    if RelatedTestIsTest(bufname) > 0
+        let relatedtest_filename = RelatedTestGetFileName(bufname)
     else
-        let relatedtest_filename = RelatedTestGetTestFileName(a:bufname)
+        let relatedtest_filename = RelatedTestGetTestFileName(bufname)
     endif
-
+    let open_strategy = ":" . g:relatedtest_open_strategy . " "
     if filereadable(relatedtest_filename)
-        exec ":e " . relatedtest_filename
+        exec open_strategy . relatedtest_filename
     else
         if s:GetInputResponse("Test file '" . relatedtest_filename . "' doesn't exists. Create a new test file (y/n)?", ['y', 'n']) == 'y'
-            exec ":e " . relatedtest_filename
+            exec open_strategy . relatedtest_filename
         endif
     endif
 endfunction

--- a/autoload/relatedtest.vim
+++ b/autoload/relatedtest.vim
@@ -1,0 +1,39 @@
+" relatedtest.vim - Vim related test plugin
+" Language:     Viml
+" Maintainer:   Walter Dal Mut (walter.dalmut AT gmail DOT com)
+"
+"       OPTIONS:
+"
+"           let g.realted_test_open_trigger = tt [default tt]
+"               Combo for open a related test
+"
+
+function! s:GetInputResponse(prompt, inputChoices)
+    echo a:prompt
+    while 1
+        let choice = tolower(nr2char(getchar()))
+        for inputChoice in a:inputChoices
+            if inputChoice == choice
+                return choice
+            endif
+        endfor
+        echo "Invalid choice. Valid choices: ". join(a:inputChoices, ',').": "
+    endwhile
+endfunction
+
+function! relatedtest#handleTT()
+    let a:bufname = bufname('%')
+    if RelatedTestIsTest(a:bufname) > 0
+        let relatedtest_filename = RelatedTestGetFileName(a:bufname)
+    else
+        let relatedtest_filename = RelatedTestGetTestFileName(a:bufname)
+    endif
+
+    if filereadable(relatedtest_filename)
+        exec ":e " . relatedtest_filename
+    else
+        if s:GetInputResponse("Test file '" . relatedtest_filename . "' doesn't exists. Create a new test file (y/n)?", ['y', 'n']) == 'y'
+            exec ":e " . relatedtest_filename
+        endif
+    endif
+endfunction

--- a/doc/vim-relatedtest.txt
+++ b/doc/vim-relatedtest.txt
@@ -42,6 +42,7 @@ Section 3: Mappings                                      *RelatedTestMappings*
 
 You can override the default mapping in your `.vimrc` configuration file >
     let g:relatedtest_open_command = '<C-t>'
+    let g:relatedtest_open_strategy = 'vsp'
 <
 
 ==============================================================================

--- a/ftplugin/go_relatedtest.vim
+++ b/ftplugin/go_relatedtest.vim
@@ -14,11 +14,11 @@ let b:relatedtest_file_sub = '_test\.go'
 let b:relatedtest_source_sub = '\.go'
 let b:relatedtest_test_regexp = '_test\.go$'
 
-function! b:relatedTestIsTest(actual_file_path)
+function! RelatedTestIsTest(actual_file_path)
     return strlen(matchstr(a:actual_file_path, b:relatedtest_test_regexp))
 endfunction
 
-function! b:relatedTestGetFileName(actual_file_path)
+function! RelatedTestGetFileName(actual_file_path)
     let relatedtest_filename = substitute(a:actual_file_path, b:relatedtest_test_regexp, b:relatedtest_source_sub, '')
 
      return relatedtest_filename
@@ -26,7 +26,7 @@ function! b:relatedTestGetFileName(actual_file_path)
 endfunction
 
 " Get the fullpath of the test file
-function! b:relatedTestGetTestFileName(actual_file_path)
+function! RelatedTestGetTestFileName(actual_file_path)
      let relatedtest_testfilename = substitute(a:actual_file_path, b:relatedtest_file_exp, b:relatedtest_file_sub, '')
 
      return relatedtest_testfilename

--- a/ftplugin/java_relatedtest.vim
+++ b/ftplugin/java_relatedtest.vim
@@ -23,7 +23,7 @@ function! RelatedTestGetFileName(actual_file_path)
     let currentfile_name = substitute(expand('%:t'), b:relatedtest_file_sub, '', '')
     let package_line = search('package')
     let package = getline(package_line)
-    let deducedImplementationFilePath = RelatedTestDeduceImplementationPath(package)
+    let deducedImplementationFilePath = s:RelatedTestDeduceImplementationPath(package)
     let deducedImplementationPath = fnamemodify(deducedImplementationFilePath, ':p:h')
     return deducedImplementationPath . '/' . currentfile_name . b:relatedtest_source_sub
 endfunction
@@ -33,20 +33,20 @@ function! RelatedTestGetTestFileName(actual_file_path)
     let currentfile_name = substitute(expand('%:t'), b:relatedtest_source_sub, '', '')
     let package_line = search('package')
     let package = getline(package_line)
-    let deducedTestFilePath = RelatedTestDeduceTestsPath(package)
+    let deducedTestFilePath = s:RelatedTestDeduceTestsPath(package)
     let deducedTestPath = fnamemodify(deducedTestFilePath, ':p:h')
     return deducedTestPath . '/' . currentfile_name . b:relatedtest_file_sub
 endfunction
 
 " Try to deduce the tests path of a package
-function! RelatedTestDeduceTestsPath(package)
+function! s:RelatedTestDeduceTestsPath(package)
     execute 'vimgrep /' . a:package . '/gj **/*' . b:relatedtest_file_sub
     let quickfixlist = getqflist()
     return bufname(quickfixlist[0].bufnr)
 endfunction
 
 " Try to deduce the implementation path of a package
-function! RelatedTestDeduceImplementationPath(package)
+function! s:RelatedTestDeduceImplementationPath(package)
     execute 'vimgrep /' . a:package . '/gj **/*' . b:relatedtest_source_sub
     let quickfixlist = getqflist()
     return bufname(quickfixlist[0].bufnr)

--- a/ftplugin/java_relatedtest.vim
+++ b/ftplugin/java_relatedtest.vim
@@ -14,39 +14,39 @@ let b:relatedtest_source_sub = '.java'
 let b:relatedtest_test_regexp = 'Test\.java$'
 
 
-function! b:relatedTestIsTest(actual_file_path)
+function! RelatedTestIsTest(actual_file_path)
     return strlen(matchstr(a:actual_file_path, b:relatedtest_test_regexp))
 endfunction
 
 " Get the fullpath of the implementation file
-function! b:relatedTestGetFileName(actual_file_path)
+function! RelatedTestGetFileName(actual_file_path)
     let currentfile_name = substitute(expand('%:t'), b:relatedtest_file_sub, '', '')
     let package_line = search('package')
     let package = getline(package_line)
-    let deducedImplementationFilePath = b:relatedTestDeduceImplementationPath(package)
+    let deducedImplementationFilePath = RelatedTestDeduceImplementationPath(package)
     let deducedImplementationPath = fnamemodify(deducedImplementationFilePath, ':p:h')
     return deducedImplementationPath . '/' . currentfile_name . b:relatedtest_source_sub
 endfunction
 
 " Get the fullpath of the test file
-function! b:relatedTestGetTestFileName(actual_file_path)
+function! RelatedTestGetTestFileName(actual_file_path)
     let currentfile_name = substitute(expand('%:t'), b:relatedtest_source_sub, '', '')
     let package_line = search('package')
     let package = getline(package_line)
-    let deducedTestFilePath = b:relatedTestDeduceTestsPath(package)
+    let deducedTestFilePath = RelatedTestDeduceTestsPath(package)
     let deducedTestPath = fnamemodify(deducedTestFilePath, ':p:h')
     return deducedTestPath . '/' . currentfile_name . b:relatedtest_file_sub
 endfunction
 
 " Try to deduce the tests path of a package
-function! b:relatedTestDeduceTestsPath(package)
+function! RelatedTestDeduceTestsPath(package)
     execute 'vimgrep /' . a:package . '/gj **/*' . b:relatedtest_file_sub
     let quickfixlist = getqflist()
     return bufname(quickfixlist[0].bufnr)
 endfunction
 
 " Try to deduce the implementation path of a package
-function! b:relatedTestDeduceImplementationPath(package)
+function! RelatedTestDeduceImplementationPath(package)
     execute 'vimgrep /' . a:package . '/gj **/*' . b:relatedtest_source_sub
     let quickfixlist = getqflist()
     return bufname(quickfixlist[0].bufnr)

--- a/ftplugin/php_relatedtest.vim
+++ b/ftplugin/php_relatedtest.vim
@@ -31,7 +31,7 @@ endfunction
 function! RelatedTestGetFileName(actual_file_path)
     let current_filename = substitute(expand('%:t'), b:relatedtest_file_sub, '', '')
 
-    let deducedImplementationFilePath = RelatedTestDeduceImplementationPath(current_filename)
+    let deducedImplementationFilePath = s:RelatedTestDeduceImplementationPath(current_filename)
     let deducedImplementationPath = fnamemodify(deducedImplementationFilePath, ':p:h')
     return deducedImplementationPath . '/' . current_filename . b:relatedtest_source_sub
 endfunction
@@ -40,20 +40,20 @@ endfunction
 function! RelatedTestGetTestFileName(actual_file_path)
     let current_filename = substitute(expand('%:t'), b:relatedtest_source_sub, '', '')
 
-    let deducedTestFilePath = RelatedTestDeduceTestsPath(current_filename)
+    let deducedTestFilePath = s:RelatedTestDeduceTestsPath(current_filename)
     let deducedTestPath = fnamemodify(deducedTestFilePath, ':p:h')
     return deducedTestPath . '/' . current_filename . b:relatedtest_file_sub
 endfunction
 
 " Try to deduce the tests path of a package
-function! RelatedTestDeduceTestsPath(package)
+function! s:RelatedTestDeduceTestsPath(package)
     execute 'vimgrep /' . a:package . '/gj '.g:relatedtest_php_tests.'**/*' . b:relatedtest_file_sub
     let quickfixlist = getqflist()
     return bufname(quickfixlist[0].bufnr)
 endfunction
 
 " Try to deduce the implementation path of a package
-function! RelatedTestDeduceImplementationPath(package)
+function! s:RelatedTestDeduceImplementationPath(package)
     execute 'vimgrep /' . a:package . '/gj '.g:relatedtest_php_src.'**/*' . b:relatedtest_source_sub
     let quickfixlist = getqflist()
     return bufname(quickfixlist[0].bufnr)

--- a/ftplugin/php_relatedtest.vim
+++ b/ftplugin/php_relatedtest.vim
@@ -23,37 +23,37 @@ if !exists('g:relatedtest_php_tests')
     let g:relatedtest_php_tests=""
 endif
 
-function! b:relatedTestIsTest(actual_file_path)
+function! RelatedTestIsTest(actual_file_path)
     return strlen(matchstr(a:actual_file_path, b:relatedtest_test_regexp))
 endfunction
 
 " Get the fullpath of the implementation file
-function! b:relatedTestGetFileName(actual_file_path)
+function! RelatedTestGetFileName(actual_file_path)
     let current_filename = substitute(expand('%:t'), b:relatedtest_file_sub, '', '')
 
-    let deducedImplementationFilePath = b:relatedTestDeduceImplementationPath(current_filename)
+    let deducedImplementationFilePath = RelatedTestDeduceImplementationPath(current_filename)
     let deducedImplementationPath = fnamemodify(deducedImplementationFilePath, ':p:h')
     return deducedImplementationPath . '/' . current_filename . b:relatedtest_source_sub
 endfunction
 
 " Get the fullpath of the test file
-function! b:relatedTestGetTestFileName(actual_file_path)
+function! RelatedTestGetTestFileName(actual_file_path)
     let current_filename = substitute(expand('%:t'), b:relatedtest_source_sub, '', '')
 
-    let deducedTestFilePath = b:relatedTestDeduceTestsPath(current_filename)
+    let deducedTestFilePath = RelatedTestDeduceTestsPath(current_filename)
     let deducedTestPath = fnamemodify(deducedTestFilePath, ':p:h')
     return deducedTestPath . '/' . current_filename . b:relatedtest_file_sub
 endfunction
 
 " Try to deduce the tests path of a package
-function! b:relatedTestDeduceTestsPath(package)
+function! RelatedTestDeduceTestsPath(package)
     execute 'vimgrep /' . a:package . '/gj '.g:relatedtest_php_tests.'**/*' . b:relatedtest_file_sub
     let quickfixlist = getqflist()
     return bufname(quickfixlist[0].bufnr)
 endfunction
 
 " Try to deduce the implementation path of a package
-function! b:relatedTestDeduceImplementationPath(package)
+function! RelatedTestDeduceImplementationPath(package)
     execute 'vimgrep /' . a:package . '/gj '.g:relatedtest_php_src.'**/*' . b:relatedtest_source_sub
     let quickfixlist = getqflist()
     return bufname(quickfixlist[0].bufnr)

--- a/plugin/relatedtest.vim
+++ b/plugin/relatedtest.vim
@@ -16,4 +16,8 @@ if !exists('g:relatedtest_open_command')
     let g:relatedtest_open_command = 'tt'
 endif
 
+if !exists('g:relatedtest_open_strategy')
+    let g:relatedtest_open_strategy = 'e'
+endif
+
 exec "nmap <silent> " . g:relatedtest_open_command . " :call relatedtest#handleTT()<CR>"

--- a/plugin/relatedtest.vim
+++ b/plugin/relatedtest.vim
@@ -16,22 +16,4 @@ if !exists('g:relatedtest_open_command')
     let g:relatedtest_open_command = 'tt'
 endif
 
-function! g:relatedTestHandleTT()
-    let a:bufname = bufname('%')
-    if b:relatedTestIsTest(a:bufname) > 0
-        let relatedtest_filename = b:relatedTestGetFileName(a:bufname)
-    else
-        let relatedtest_filename = b:relatedTestGetTestFileName(a:bufname)
-    endif
-
-    if filereadable(relatedtest_filename)
-        exec ":e " . relatedtest_filename
-    else
-        if input("Test file '" . relatedtest_filename . "' doesn't exists. Create a new test file [Y/N]? ", 'Y') == 'Y'
-            exec ":e " . relatedtest_filename
-        endif
-    endif
-endfunction
-
-exec "nmap <silent> " . g:relatedtest_open_command . " :call g:relatedTestHandleTT()<CR>"
-
+exec "nmap <silent> " . g:relatedtest_open_command . " :call relatedtest#handleTT()<CR>"


### PR DESCRIPTION
Changelog:
- Added opening strategies:  now one can override the default opening strategy `e` with any vimscript command such as `vsp`, `tabnew` and others using `let g:relatedtest_open_strategy = 'vsp'`
- Reorganized plugin structure: The vim runtime provides a way to load plugin specific functions only when needed. Having a `g:relatedTestHandleTT()` function in the `plugin/relatedtest.vim` file means that every time vim is opened that function wil be loaded. I moved this function in the `autoload/relatedtest.vim` file renaming it to `relatedtest#handleTT` to tell vim to load this only when needed.

resolve #6 
